### PR TITLE
fix: buffer overflow on nickname selection

### DIFF
--- a/processing.c
+++ b/processing.c
@@ -246,7 +246,7 @@ void request_nickname() {
     flushinp();
     timeout(-1);
     turn_on_header_color(true);
-    getstr(act_nick);
+    getnstr(act_nick, sizeof(act_nick) - 1);
     turn_off_header_color(true);
     curs_set(0);
     noecho();

--- a/processing.c
+++ b/processing.c
@@ -186,7 +186,7 @@ int process_run_level(level *inplvl) {
   int score = run_level(inplvl, &status);
 
   int hof = get_hall_of_fame(act_nick, inplvl->levelnumber);
-  char outstring[128] = {0};
+  char outstring[255] = {0};
   if (score > hof && score > 0) {
     sprintf(outstring,
             "GAME OVER! NEW HIGH SCORE FOR THIS LEVEL! %s - YOUR SCORE: %d "

--- a/rendering.c
+++ b/rendering.c
@@ -1209,7 +1209,7 @@ bool render_hof(config_option_t hoff, int yoff, bool dofree,
       if (actoff >= MAPSIZEY - 1) skipalr = true;
 
       if (actoff >= yoff && !skipalr) {
-        char outtext[120] = {0};
+        char outtext[255] = {0};
         char *havelvl = strstr(hoff->key, "#lvl_");
         char nickname[64] = {0};
         memcpy(nickname, hoff->key,


### PR DESCRIPTION
Select [`getstr` variant](https://linux.die.net/man/3/getstr) which respects the size of buffer it outputs to. 